### PR TITLE
Fix imports to use absolute paths

### DIFF
--- a/decisions/utils.go
+++ b/decisions/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	u "../utils"
+	u "github.com/Zebbeni/protozoa/utils"
 )
 
 // GetRandomCondition returns a random Condition from the Conditions array

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"time"
 
-	c "./constants"
-	s "./simulation"
+	c "github.com/Zebbeni/protozoa/constants"
+	s "github.com/Zebbeni/protozoa/simulation"
 
 	"github.com/hajimehoshi/ebiten"
 	"github.com/hajimehoshi/ebiten/ebitenutil"

--- a/models/organism.go
+++ b/models/organism.go
@@ -6,9 +6,9 @@ import (
 	"math"
 	"math/rand"
 
-	c "../constants"
-	d "../decisions"
-	u "../utils"
+	c "github.com/Zebbeni/protozoa/constants"
+	d "github.com/Zebbeni/protozoa/decisions"
+	u "github.com/Zebbeni/protozoa/utils"
 )
 
 // OrganismState defines type of action Organism is doing

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"image/color"
 
-	c "../constants"
-	m "../models"
-	w "../world"
+	c "github.com/Zebbeni/protozoa/constants"
+	m "github.com/Zebbeni/protozoa/models"
+	w "github.com/Zebbeni/protozoa/world"
 	"github.com/hajimehoshi/ebiten"
 	"github.com/hajimehoshi/ebiten/ebitenutil"
 )

--- a/test/configs.go
+++ b/test/configs.go
@@ -1,10 +1,10 @@
 package test
 
 import (
-	c "../constants"
-	m "../models"
-	s "../simulation"
-	w "../world"
+	c "github.com/Zebbeni/protozoa/constants"
+	m "github.com/Zebbeni/protozoa/models"
+	s "github.com/Zebbeni/protozoa/simulation"
+	w "github.com/Zebbeni/protozoa/world"
 )
 
 // define configs to create a simple 5 x 5 simulation

--- a/test/simulation_test.go
+++ b/test/simulation_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	s "../simulation"
+	s "github.com/Zebbeni/protozoa/simulation"
 )
 
 func TestSimulateOneCycle(t *testing.T) {

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -6,8 +6,8 @@ import (
 	"math/rand"
 	"testing"
 
-	d "../decisions"
-	u "../utils"
+	d "github.com/Zebbeni/protozoa/decisions"
+	u "github.com/Zebbeni/protozoa/utils"
 )
 
 func TestCalculateDirectionVectors(t *testing.T) {

--- a/world/world.go
+++ b/world/world.go
@@ -1,7 +1,7 @@
 package world
 
 import (
-	m "../models"
+	m "github.com/Zebbeni/protozoa/models"
 )
 
 // World contains all attributes defining the current simulation environment


### PR DESCRIPTION
Thank you for using Ebiten!

This PR replaces import paths to use absolute ones so that this package is go-gettable and easy to execute.