### PR TITLE
Render diffs only

### DIFF
--- a/food/world_api.go
+++ b/food/world_api.go
@@ -1,0 +1,12 @@
+package food
+
+import (
+	"github.com/Zebbeni/protozoa/utils"
+)
+
+// WorldAPI provides functions to make changes
+type WorldAPI interface {
+	// AddGridPointToUpdate indicates a point on the grid has been updated
+	// and needs to be re-rendered
+	AddGridPointToUpdate(point utils.Point)
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"image/color"
 	"log"
 	"math/rand"
 	"runtime"
@@ -17,9 +16,8 @@ import (
 )
 
 var (
-	backgroundColor = color.RGBA{15, 5, 15, 255}
-	filter          = ebiten.FilterLinear
-	simulation      s.Simulation
+	filter     = ebiten.FilterLinear
+	simulation s.Simulation
 )
 
 func update(screen *ebiten.Image) error {
@@ -28,8 +26,6 @@ func update(screen *ebiten.Image) error {
 	if ebiten.IsRunningSlowly() {
 		return nil
 	}
-	screen.Clear()
-	ebitenutil.DrawRect(screen, 0, 0, c.ScreenWidth, c.ScreenHeight, backgroundColor)
 	simulation.Render(screen)
 
 	var m runtime.MemStats

--- a/organism/world_api.go
+++ b/organism/world_api.go
@@ -27,6 +27,9 @@ type WorldChangeAPI interface {
 	// RemoveFoodAtPoint requests removing some amount of food at a Point
 	// returns how much food was actually removed
 	RemoveFoodAtPoint(point utils.Point, value int) int
+	// AddGridPointToUpdate indicates a point on the grid has been updated
+	// and needs to be re-rendered
+	AddGridPointToUpdate(point utils.Point)
 }
 
 // WorldAPI provides functions needed to lookup and make changes to world objects

--- a/utils/geometry.go
+++ b/utils/geometry.go
@@ -36,6 +36,18 @@ func GetRandomPoint() Point {
 	}
 }
 
+// GetAllPointsNear returns all points that lie in a square within a given
+// distance from a single point
+func GetAllPointsNear(point Point, distance int) []Point {
+	points := make([]Point, 0, 9)
+	for x := -distance; x <= distance; x++ {
+		for y := -distance; y <= distance; y++ {
+			points = append(points, Point{X: point.X + x, Y: point.Y + y})
+		}
+	}
+	return points
+}
+
 // GetRandomDirection returns a point representing a random direction
 func GetRandomDirection() Point {
 	return Directions[rand.Intn(len(Directions))]

--- a/world/world.go
+++ b/world/world.go
@@ -13,13 +13,16 @@ type World struct {
 
 	FoodManager     *manager.FoodManager
 	OrganismManager *manager.OrganismManager
+
+	PointsToUpdate map[string]utils.Point
 }
 
 // NewWorld constructs a new World objedt with newly initialized attributes
 func NewWorld() *World {
 	world := World{}
-	world.FoodManager = manager.NewFoodManager()
+	world.FoodManager = manager.NewFoodManager(&world)
 	world.OrganismManager = manager.NewOrganismManager(&world)
+	world.ResetGridPointsToUpdate()
 	return &world
 }
 
@@ -87,4 +90,15 @@ func (w *World) AddFoodAtPoint(point utils.Point, value int) int {
 // amount of food added.
 func (w *World) RemoveFoodAtPoint(point utils.Point, value int) int {
 	return w.FoodManager.RemoveFoodAtPoint(point, value)
+}
+
+// ResetGridPointsToUpdate clears the current pointsToUpdate map
+func (w *World) ResetGridPointsToUpdate() {
+	w.PointsToUpdate = make(map[string]utils.Point)
+}
+
+// AddGridPointToUpdate indicates a point on the grid has been updated
+// and needs to be re-rendered
+func (w *World) AddGridPointToUpdate(point utils.Point) {
+	w.PointsToUpdate[point.ToString()] = point
 }


### PR DESCRIPTION
Right now rendering takes up to 9x as long as the logic to update the simulation grid. When we update each cycle, let's keep a list of all points that need to be rerendered rather than re-rendering each one (ie. only render the diff)