### PR TITLE
Create a private, globally-referenced variable to store and reference constants

### DIFF
--- a/config/globals.go
+++ b/config/globals.go
@@ -5,6 +5,48 @@ import (
 	"io"
 )
 
+var constants *Globals
+
+// SetGlobals allows a one-time setting of all globally-referenced constants
+func SetGlobals(g *Globals) {
+	if constants != nil {
+		return
+	}
+	constants = g
+}
+
+func GridUnitSize() int                          { return constants.GridUnitSize }
+func GridWidth() int                             { return constants.GridWidth }
+func GridHeight() int                            { return constants.GridHeight }
+func GridUnitsWide() int                         { return constants.GridUnitsWide }
+func GridUnitsHigh() int                         { return constants.GridUnitsHigh }
+func ScreenWidth() int                           { return constants.ScreenWidth }
+func ScreenHeight() int                          { return constants.ScreenHeight }
+func PopulationUpdateInterval() int              { return constants.PopulationUpdateInterval }
+func ChanceToAddOrganism() float64               { return constants.ChanceToAddOrganism }
+func ChanceToAddFoodItem() float64               { return constants.ChanceToAddFoodItem }
+func MaxFoodValue() int                          { return constants.MaxFoodValue }
+func MinFoodValue() int                          { return constants.MinFoodValue }
+func MaxCyclesBetweenSpawns() int                { return constants.MaxCyclesBetweenSpawns }
+func MinSpawnHealth() float64                    { return constants.MinSpawnHealth }
+func MaxSpawnHealthPercent() float64             { return constants.MaxSpawnHealthPercent }
+func MinChanceToMutateDecisionTree() float64     { return constants.MinChanceToMutateDecisionTree }
+func MaxChanceToMutateDecisionTree() float64     { return constants.MaxChanceToMutateDecisionTree }
+func MaxCyclesToEvaluateDecisionTree() int       { return constants.MaxCyclesToEvaluateDecisionTree }
+func MaxOrganisms() int                          { return constants.MaxOrganisms }
+func GrowthFactor() float64                      { return constants.GrowthFactor }
+func MaximumMaxSize() float64                    { return constants.MaximumMaxSize }
+func MinimumMaxSize() float64                    { return constants.MinimumMaxSize }
+func HealthChangePerCycle() float64              { return constants.HealthChangePerCycle }
+func HealthChangeFromBeingIdle() float64         { return constants.HealthChangeFromBeingIdle }
+func HealthChangeFromTurning() float64           { return constants.HealthChangeFromTurning }
+func HealthChangeFromMoving() float64            { return constants.HealthChangeFromMoving }
+func HealthChangeFromEatingAttempt() float64     { return constants.HealthChangeFromEatingAttempt }
+func HealthChangeFromAttacking() float64         { return constants.HealthChangeFromAttacking }
+func HealthChangeInflictedByAttack() float64     { return constants.HealthChangeInflictedByAttack }
+func HealthChangeFromFeeding() float64           { return constants.HealthChangeFromFeeding }
+func HealthPercentToChangeDecisionTree() float64 { return constants.HealthPercentToChangeDecisionTree }
+
 type Globals struct {
 	// Drawing parameters
 	GridUnitSize  int `json:"grid_unit_size"`

--- a/config/globals.go
+++ b/config/globals.go
@@ -7,7 +7,7 @@ import (
 
 var constants *Globals
 
-// SetGlobals allows a one-time setting of all globally-referenced constants
+// SetGlobals allows a one-time initialization of all globally-referenced constants
 func SetGlobals(g *Globals) {
 	if constants != nil {
 		return

--- a/main.go
+++ b/main.go
@@ -28,5 +28,7 @@ func main() {
 		globals = &p
 	}
 
-	runner.RunSimulation(opts, globals)
+	config.SetGlobals(globals)
+
+	runner.RunSimulation(opts)
 }

--- a/manager/food.go
+++ b/manager/food.go
@@ -4,33 +4,30 @@ import (
 	"math"
 	"math/rand"
 
-	"github.com/Zebbeni/protozoa/config"
+	c "github.com/Zebbeni/protozoa/config"
 	"github.com/Zebbeni/protozoa/food"
 	u "github.com/Zebbeni/protozoa/utils"
 )
 
 // FoodManager contains 2D array of all food values
 type FoodManager struct {
-	*config.Globals
-
 	api food.API
 
 	Items map[string]*food.Item
 }
 
 // NewFoodManager initializes a new foodItem map of MinFood
-func NewFoodManager(api food.API, g *config.Globals) *FoodManager {
+func NewFoodManager(api food.API) *FoodManager {
 	m := &FoodManager{
 		api:   api,
 		Items: make(map[string]*food.Item),
 	}
-	m.Globals = g
 	return m
 }
 
 // Update is called on every cycle and adds new FoodItems at a constant rate
 func (m *FoodManager) Update() {
-	if rand.Float64() < m.ChanceToAddFoodItem {
+	if rand.Float64() < c.ChanceToAddFoodItem() {
 		m.AddRandomFoodItem()
 	}
 }
@@ -43,9 +40,9 @@ func (m *FoodManager) FoodCount() int {
 // AddRandomFoodItem attempts to add a FoodItem object to a random location
 // Gives up if first attempt to place food fails.
 func (m *FoodManager) AddRandomFoodItem() {
-	x := rand.Intn(m.GridUnitsWide)
-	y := rand.Intn(m.GridUnitsHigh)
-	value := rand.Intn(m.MaxFoodValue)
+	x := rand.Intn(c.GridUnitsWide())
+	y := rand.Intn(c.GridUnitsHigh())
+	value := rand.Intn(c.MaxFoodValue())
 	point := u.Point{X: x, Y: y}
 	if added := m.AddFoodAtPoint(point, value); added > 0 {
 		m.api.AddGridPointToUpdate(point)
@@ -64,16 +61,16 @@ func (m *FoodManager) AddFoodAtPoint(point u.Point, value int) int {
 	locationString := point.ToString()
 	item, exists := m.Items[locationString]
 	if !exists {
-		value = int(math.Min(math.Max(0.0, float64(value)), float64(m.MaxFoodValue)))
+		value = int(math.Min(math.Max(0.0, float64(value)), float64(c.MaxFoodValue())))
 		m.Items[locationString] = food.NewItem(point, value)
 		return value
 	}
 
 	originalValue := item.Value
 	item.Value += value
-	if item.Value > m.MaxFoodValue {
-		item.Value = m.MaxFoodValue
-		return m.MaxFoodValue - originalValue
+	if item.Value > c.MaxFoodValue() {
+		item.Value = c.MaxFoodValue()
+		return c.MaxFoodValue() - originalValue
 	}
 	return value
 }
@@ -97,7 +94,7 @@ func (m *FoodManager) RemoveFoodAtPoint(point u.Point, value int) int {
 	originalValue := item.Value
 	item.Value -= value
 
-	if item.Value < m.MinFoodValue {
+	if item.Value < c.MinFoodValue() {
 		delete(m.Items, locationString)
 	}
 

--- a/organism/traits.go
+++ b/organism/traits.go
@@ -1,7 +1,7 @@
 package organism
 
 import (
-	"github.com/Zebbeni/protozoa/config"
+	c "github.com/Zebbeni/protozoa/config"
 	"image/color"
 	"math"
 	"math/rand"
@@ -26,14 +26,14 @@ type Traits struct {
 	CyclesToEvaluateDecisionTree int
 }
 
-func newRandomTraits(p *config.Globals) Traits {
+func newRandomTraits() Traits {
 	organismColor := u.GetRandomColor()
-	maxSize := rand.Float64() * p.MaximumMaxSize
-	spawnHealth := rand.Float64() * maxSize * p.MaxSpawnHealthPercent
+	maxSize := rand.Float64() * c.MaximumMaxSize()
+	spawnHealth := rand.Float64() * maxSize * c.MaxSpawnHealthPercent()
 	minHealthToSpawn := spawnHealth + rand.Float64()*(maxSize-spawnHealth)
-	minCyclesBetweenSpawns := rand.Intn(p.MaxCyclesBetweenSpawns)
-	chanceToMutateDecisionTree := math.Max(p.MinChanceToMutateDecisionTree, rand.Float64()*p.MaxChanceToMutateDecisionTree)
-	cyclesToEvaluateDecisionTree := rand.Intn(p.MaxCyclesToEvaluateDecisionTree)
+	minCyclesBetweenSpawns := rand.Intn(c.MaxCyclesBetweenSpawns())
+	chanceToMutateDecisionTree := math.Max(c.MinChanceToMutateDecisionTree(), rand.Float64()*c.MaxChanceToMutateDecisionTree())
+	cyclesToEvaluateDecisionTree := rand.Intn(c.MaxCyclesToEvaluateDecisionTree())
 	return Traits{
 		OrganismColor:                organismColor,
 		MaxSize:                      maxSize,
@@ -45,20 +45,20 @@ func newRandomTraits(p *config.Globals) Traits {
 	}
 }
 
-func (t Traits) copyMutated(p *config.Globals) Traits {
+func (t Traits) copyMutated() Traits {
 	organismColor := mutateColor(t.OrganismColor)
 	// maxSize = previous +- previous +- <5.0, bounded by MinimumMaxSize and MaximumMaxSize
-	maxSize := mutateFloat(t.MaxSize, 5.0, p.MinimumMaxSize, p.MaximumMaxSize)
+	maxSize := mutateFloat(t.MaxSize, 5.0, c.MinimumMaxSize(), c.MaximumMaxSize())
 	// minCyclesBetweenSpawns = previous +- <=5, bounded by 0 and MaxCyclesBetweenSpawns
-	minCyclesBetweenSpawns := mutateInt(t.MinCyclesBetweenSpawns, 5, 0, p.MaxCyclesBetweenSpawns)
+	minCyclesBetweenSpawns := mutateInt(t.MinCyclesBetweenSpawns, 5, 0, c.MaxCyclesBetweenSpawns())
 	// spawnHealth = previous +- <0.05, bounded by MinSpawnHealth and maxSize
-	spawnHealth := mutateFloat(t.SpawnHealth, 0.1, p.MinSpawnHealth, maxSize*p.MaxSpawnHealthPercent)
+	spawnHealth := mutateFloat(t.SpawnHealth, 0.1, c.MinSpawnHealth(), maxSize*c.MaxSpawnHealthPercent())
 	// minHealthToSpawn = previous +- <5.0, bounded by spawnHealthPercent and maxSize (both calculated above)
 	minHealthToSpawn := mutateFloat(t.MinHealthToSpawn, 5.0, spawnHealth, maxSize)
 	// chanceToMutateDecisionTree = previous +- <0.01, bounded by MinChanceToMutateDecisionTree and MaxChanceToMutateDecisionTree
-	chanceToMutateDecisionTree := mutateFloat(t.ChanceToMutateDecisionTree, 0.01, p.MinChanceToMutateDecisionTree, p.MaxChanceToMutateDecisionTree)
+	chanceToMutateDecisionTree := mutateFloat(t.ChanceToMutateDecisionTree, 0.01, c.MinChanceToMutateDecisionTree(), c.MaxChanceToMutateDecisionTree())
 	// cyclesToEvaluateDecisionTree = previous +1, +0 or +(-1), bounded by 1 and CyclesToEvaluateDecisionTree
-	cyclesToEvaluateDecisionTree := mutateInt(t.CyclesToEvaluateDecisionTree, 1, 1, p.MaxCyclesToEvaluateDecisionTree)
+	cyclesToEvaluateDecisionTree := mutateInt(t.CyclesToEvaluateDecisionTree, 1, 1, c.MaxCyclesToEvaluateDecisionTree())
 	return Traits{
 		OrganismColor:                organismColor,
 		MaxSize:                      maxSize,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten"
 
-	"github.com/Zebbeni/protozoa/config"
+	c "github.com/Zebbeni/protozoa/config"
 	r "github.com/Zebbeni/protozoa/resources"
 	"github.com/Zebbeni/protozoa/simulation"
 	"github.com/Zebbeni/protozoa/ux"
@@ -39,14 +39,14 @@ func update(screen *ebiten.Image) error {
 	//}
 }
 
-func RunSimulation(opts *config.Options, g *config.Globals) {
+func RunSimulation(opts *c.Options) {
 	r.Init()
 	rand.Seed(0)
 
 	if opts.IsHeadless {
 		sumAllCycles := 0
 		for count := 0; count < opts.TrialCount; count++ {
-			sim = simulation.NewSimulation(g)
+			sim = simulation.NewSimulation()
 			start := time.Now()
 			for !sim.IsDone() {
 				sim.Update()
@@ -58,9 +58,9 @@ func RunSimulation(opts *config.Options, g *config.Globals) {
 		avgCycles := sumAllCycles / opts.TrialCount
 		fmt.Printf("\nAverage number of cycles to reach 5000: %d\n", avgCycles)
 	} else {
-		sim = simulation.NewSimulation(g)
+		sim = simulation.NewSimulation()
 		ui = ux.NewInterface(sim)
-		if err := ebiten.Run(update, sim.ScreenWidth, sim.ScreenHeight, 1, "Globals"); err != nil {
+		if err := ebiten.Run(update, c.ScreenWidth(), c.ScreenHeight(), 1, "Globals"); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -2,7 +2,7 @@ package simulation
 
 import (
 	"fmt"
-	"github.com/Zebbeni/protozoa/config"
+	c "github.com/Zebbeni/protozoa/config"
 	"github.com/Zebbeni/protozoa/food"
 	"github.com/Zebbeni/protozoa/manager"
 	"github.com/Zebbeni/protozoa/organism"
@@ -12,8 +12,6 @@ import (
 
 // Simulation contains a list of forces, particles, and drawing settings
 type Simulation struct {
-	*config.Globals
-
 	organismManager *manager.OrganismManager
 	foodManager     *manager.FoodManager
 
@@ -23,14 +21,13 @@ type Simulation struct {
 }
 
 // NewSimulation returns a simulation with generated world and organisms
-func NewSimulation(g *config.Globals) *Simulation {
+func NewSimulation() *Simulation {
 	sim := &Simulation{
 		cycle:         0,
 		UpdatedPoints: make(map[string]utils.Point),
 	}
-	sim.foodManager = manager.NewFoodManager(sim, g)
-	sim.organismManager = manager.NewOrganismManager(sim, g)
-	sim.Globals = g
+	sim.foodManager = manager.NewFoodManager(sim)
+	sim.organismManager = manager.NewOrganismManager(sim)
 
 	return sim
 }
@@ -48,8 +45,8 @@ func (s *Simulation) UpdateCycle() {
 
 // IsDone returns true if end condition met
 func (s *Simulation) IsDone() bool {
-	if s.GetNumOrganisms() >= s.MaxOrganisms {
-		fmt.Printf("\nSimulation ended with %d organisms alive.", s.MaxOrganisms)
+	if s.GetNumOrganisms() >= c.MaxOrganisms() {
+		fmt.Printf("\nSimulation ended with %d organisms alive.", c.MaxOrganisms())
 		return true
 	}
 	return false

--- a/utils/geometry.go
+++ b/utils/geometry.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	c "github.com/Zebbeni/protozoa/config"
 	"math/rand"
 )
 
@@ -53,7 +54,7 @@ func GetRandomDirection() Point {
 
 // Add add a given Point and returns the result
 func (p Point) Add(toAdd Point) Point {
-	return Point{X: p.X + toAdd.X, Y: p.Y + toAdd.Y}
+	return Point{X: p.X + toAdd.X, Y: p.Y + toAdd.Y}.Wrap()
 }
 
 // Times multiplies a given value and returns the result
@@ -65,10 +66,10 @@ func (p *Point) Times(toMultiply int) Point {
 }
 
 // Wrap returns a point value after wrapping it around the grid
-func (p Point) Wrap(width, height int) Point {
+func (p Point) Wrap() Point {
 	return Point{
-		X: (p.X + width) % width,
-		Y: (p.Y + height) % height,
+		X: (p.X + c.GridUnitsWide()) % c.GridUnitsWide(),
+		Y: (p.Y + c.GridUnitsHigh()) % c.GridUnitsHigh(),
 	}
 }
 

--- a/ux/graph.go
+++ b/ux/graph.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten"
 
+	c "github.com/Zebbeni/protozoa/config"
 	s "github.com/Zebbeni/protozoa/simulation"
 )
 
@@ -54,17 +55,17 @@ func (g *Graph) Render() *ebiten.Image {
 
 func (g *Graph) renderAll() *ebiten.Image {
 	// add 1 to make sure cycle 0 gives us a bar count of 1
-	barCount := 1 + (g.simulation.Cycle() / g.simulation.PopulationUpdateInterval)
+	barCount := 1 + (g.simulation.Cycle() / c.PopulationUpdateInterval())
 	barWidth := realGraphWidth / float64(barCount)
 	g.maxTotalPopulation = g.getMaxPopulation()
 	img, _ := ebiten.NewImage(realGraphWidth, realGraphHeight, ebiten.FilterDefault)
 
-	for cycle := 0; cycle <= g.simulation.Cycle(); cycle += g.simulation.PopulationUpdateInterval {
+	for cycle := 0; cycle <= g.simulation.Cycle(); cycle += c.PopulationUpdateInterval() {
 		barImage, graphBarPopulation := g.renderGraphBar(cycle)
 		options := &ebiten.DrawImageOptions{}
 		scaleX := barWidth / float64(barImage.Bounds().Dx())
 		scaleY := float64(graphBarPopulation) / float64(g.maxTotalPopulation)
-		xOffset := float64(cycle/g.simulation.PopulationUpdateInterval) * barWidth
+		xOffset := float64(cycle/c.PopulationUpdateInterval()) * barWidth
 		yOffset := realGraphHeight - (float64(barImage.Bounds().Dy()) * scaleY)
 		options.GeoM.Scale(scaleX, scaleY)
 		options.GeoM.Translate(xOffset, yOffset)
@@ -78,7 +79,7 @@ func (g *Graph) renderAll() *ebiten.Image {
 }
 
 func (g *Graph) renderNewBar() *ebiten.Image {
-	barCount := 1 + (g.simulation.Cycle() / g.simulation.PopulationUpdateInterval)
+	barCount := 1 + (g.simulation.Cycle() / c.PopulationUpdateInterval())
 	barWidth := realGraphWidth / float64(barCount)
 	barImage, graphBarPopulation := g.renderGraphBar(g.simulation.Cycle())
 
@@ -122,14 +123,14 @@ func (g *Graph) renderNewBar() *ebiten.Image {
 // draw and return an image of the stacked graph bar for a single cycle
 // also return the number of
 func (g *Graph) renderGraphBar(cycle int) (*ebiten.Image, int) {
-	barCount := 1 + (g.simulation.Cycle() / g.simulation.PopulationUpdateInterval)
+	barCount := 1 + (g.simulation.Cycle() / c.PopulationUpdateInterval())
 	realBarWidth := realGraphWidth / barCount
 
 	populationMap := g.simulation.GetHistory()
 	ancestorColorMap := g.simulation.GetAncestorColors()
 	sortedAncestorIDs := g.simulation.GetAncestorsSorted()
 
-	previousFamilyPopulations := populationMap[cycle-g.simulation.PopulationUpdateInterval]
+	previousFamilyPopulations := populationMap[cycle-c.PopulationUpdateInterval()]
 	prevTotal := getTotalPopulation(previousFamilyPopulations)
 	newFamilyPopulations := populationMap[cycle]
 	newTotal := getTotalPopulation(newFamilyPopulations)
@@ -207,7 +208,7 @@ func getTotalPopulation(populationMap map[int]int16) int {
 
 func (g *Graph) getMaxPopulation() int {
 	maxTotal := int16(0)
-	for cycle := 0; cycle <= g.simulation.Cycle(); cycle += g.simulation.PopulationUpdateInterval {
+	for cycle := 0; cycle <= g.simulation.Cycle(); cycle += c.PopulationUpdateInterval() {
 		total := g.getPopulationByCycle(cycle)
 		if total > maxTotal {
 			maxTotal = total
@@ -235,5 +236,5 @@ func (g *Graph) shouldRefresh() bool {
 }
 
 func (g *Graph) shouldAddBar() bool {
-	return g.simulation.Cycle()%g.simulation.PopulationUpdateInterval == 0
+	return g.simulation.Cycle()%c.PopulationUpdateInterval() == 0
 }

--- a/ux/grid.go
+++ b/ux/grid.go
@@ -1,7 +1,7 @@
 package ux
 
 import (
-	"github.com/Zebbeni/protozoa/config"
+	c "github.com/Zebbeni/protozoa/config"
 	"image/color"
 
 	"github.com/Zebbeni/protozoa/decisions"
@@ -26,8 +26,6 @@ var (
 )
 
 type Grid struct {
-	*config.Globals
-
 	simulation        *s.Simulation
 	previousGridImage *ebiten.Image
 	selectedID        int
@@ -39,14 +37,13 @@ func NewGrid(simulation *s.Simulation) *Grid {
 		previousGridImage: nil,
 		selectedID:        -1,
 	}
-	g.Globals = simulation.Globals
 	return g
 }
 
 // Render draws all organisms and food on the simulation grid
 func (g *Grid) Render() *ebiten.Image {
-	gridImage, _ := ebiten.NewImage(g.GridWidth, g.GridHeight, ebiten.FilterDefault)
-	ebitenutil.DrawRect(gridImage, 0, 0, float64(g.GridWidth), float64(g.GridHeight), gridBackground)
+	gridImage, _ := ebiten.NewImage(c.GridWidth(), c.GridHeight(), ebiten.FilterDefault)
+	ebitenutil.DrawRect(gridImage, 0, 0, float64(c.GridWidth()), float64(c.GridHeight()), gridBackground)
 
 	mostReproductiveID := g.simulation.GetMostReproductiveID()
 	// Come up with a better way to trigger a refresh than this
@@ -54,7 +51,7 @@ func (g *Grid) Render() *ebiten.Image {
 		foodItems := g.simulation.GetFoodItems()
 		organismInfo := g.simulation.GetAllOrganismInfo()
 
-		ebitenutil.DrawRect(gridImage, 0, 0, float64(g.GridWidth), float64(g.GridHeight), gridBackground)
+		ebitenutil.DrawRect(gridImage, 0, 0, float64(c.GridWidth()), float64(c.GridHeight()), gridBackground)
 		for _, foodItem := range foodItems {
 			g.renderFood(foodItem, gridImage)
 		}
@@ -69,8 +66,8 @@ func (g *Grid) Render() *ebiten.Image {
 
 		for _, point := range g.simulation.UpdatedPoints {
 			// paint background over grid square to update first
-			x, y := point.X*g.GridUnitSize, point.Y*g.GridUnitSize
-			ebitenutil.DrawRect(gridImage, float64(x), float64(y), float64(g.GridUnitSize), float64(g.GridUnitSize), gridBackground)
+			x, y := point.X*c.GridUnitSize(), point.Y*c.GridUnitSize()
+			ebitenutil.DrawRect(gridImage, float64(x), float64(y), float64(c.GridUnitSize()), float64(c.GridUnitSize()), gridBackground)
 			if item := g.simulation.GetFoodAtPoint(point); item != nil {
 				g.renderFood(item, gridImage)
 				continue
@@ -82,7 +79,7 @@ func (g *Grid) Render() *ebiten.Image {
 		}
 	}
 
-	g.previousGridImage, _ = ebiten.NewImage(g.GridWidth, g.GridHeight, ebiten.FilterDefault)
+	g.previousGridImage, _ = ebiten.NewImage(c.GridWidth(), c.GridHeight(), ebiten.FilterDefault)
 
 	err := g.previousGridImage.DrawImage(gridImage, nil)
 	if err != nil {
@@ -90,7 +87,7 @@ func (g *Grid) Render() *ebiten.Image {
 	}
 
 	if info := g.simulation.GetOrganismInfoByID(g.selectedID); info != nil {
-		selectionBox, _ := ebiten.NewImage(g.GridWidth, g.GridHeight, ebiten.FilterDefault)
+		selectionBox, _ := ebiten.NewImage(c.GridWidth(), c.GridHeight(), ebiten.FilterDefault)
 		g.renderSelection(info.Location, selectionBox, info.Color)
 
 		err := gridImage.DrawImage(selectionBox, nil)
@@ -110,25 +107,25 @@ func (g *Grid) shouldRefresh() bool {
 
 // renderSelection draws a square around a single item on the grid
 func (g *Grid) renderSelection(point utils.Point, img *ebiten.Image, col color.Color) {
-	x, y := float64(point.X*g.GridUnitSize), float64(point.Y*g.GridUnitSize)
-	ebitenutil.DrawLine(img, x-2, y-2, x+float64(g.GridUnitSize)+3, y-2, col)                                                 // top
-	ebitenutil.DrawLine(img, x-2, y-2, x-2, y+float64(g.GridUnitSize)+3, col)                                                 // left
-	ebitenutil.DrawLine(img, x-2, y+float64(g.GridUnitSize)+3, x+float64(g.GridUnitSize)+3, y+float64(g.GridUnitSize)+3, col) // bottom
-	ebitenutil.DrawLine(img, x+float64(g.GridUnitSize)+3, y-2, x+float64(g.GridUnitSize)+3, y+float64(g.GridUnitSize)+3, col) // right
+	x, y := float64(point.X*c.GridUnitSize()), float64(point.Y*c.GridUnitSize())
+	ebitenutil.DrawLine(img, x-2, y-2, x+float64(c.GridUnitSize())+3, y-2, col)                                                     // top
+	ebitenutil.DrawLine(img, x-2, y-2, x-2, y+float64(c.GridUnitSize())+3, col)                                                     // left
+	ebitenutil.DrawLine(img, x-2, y+float64(c.GridUnitSize())+3, x+float64(c.GridUnitSize())+3, y+float64(c.GridUnitSize())+3, col) // bottom
+	ebitenutil.DrawLine(img, x+float64(c.GridUnitSize())+3, y-2, x+float64(c.GridUnitSize())+3, y+float64(c.GridUnitSize())+3, col) // right
 }
 
 // renderFood draws a food source to the given image
 func (g *Grid) renderFood(item *food.Item, img *ebiten.Image) {
-	x := float64(item.Point.X) * float64(g.GridUnitSize)
-	y := float64(item.Point.Y) * float64(g.GridUnitSize)
+	x := float64(item.Point.X) * float64(c.GridUnitSize())
+	y := float64(item.Point.Y) * float64(c.GridUnitSize())
 	alpha := 60
 	foodColor := color.RGBA{R: 100, G: 255, B: 100, A: uint8(alpha)}
 
 	value := float64(item.Value)
 	foodSize := sizeSmall
-	if value < float64(g.MaxFoodValue)*0.4375 {
+	if value < float64(c.MaxFoodValue())*0.4375 {
 		foodSize = sizeSmall
-	} else if value < float64(g.MaxFoodValue)*0.8125 {
+	} else if value < float64(c.MaxFoodValue())*0.8125 {
 		foodSize = sizeMedium
 	} else {
 		foodSize = sizeLarge
@@ -139,13 +136,13 @@ func (g *Grid) renderFood(item *food.Item, img *ebiten.Image) {
 
 // renderOrganism draws a food source to the given image
 func (g *Grid) renderOrganism(info *organism.Info, img *ebiten.Image, mostReproductiveID int) {
-	point := info.Location.Times(g.GridUnitSize)
+	point := info.Location.Times(c.GridUnitSize())
 	x, y := float64(point.X), float64(point.Y)
 
 	organismSize := sizeSmall
-	if info.Size < g.MaximumMaxSize*0.4375 {
+	if info.Size < c.MaximumMaxSize()*0.4375 {
 		organismSize = sizeSmall
-	} else if info.Size < g.MaximumMaxSize*0.8125 {
+	} else if info.Size < c.MaximumMaxSize()*0.8125 {
 		organismSize = sizeMedium
 	} else {
 		organismSize = sizeLarge
@@ -173,5 +170,5 @@ func (g *Grid) drawSquare(screen *ebiten.Image, x, y float64, sz size, col color
 		break
 	}
 
-	ebitenutil.DrawRect(screen, x+padding, y+padding, float64(g.GridUnitSize)-(2*padding), float64(g.GridUnitSize)-(2*padding), col)
+	ebitenutil.DrawRect(screen, x+padding, y+padding, float64(c.GridUnitSize())-(2*padding), float64(c.GridUnitSize())-(2*padding), col)
 }


### PR DESCRIPTION
This is a proposed change to the `config-objects` branch to store config values in a single private variable with public getters, so we can access them anywhere without having to pass a Config object through all the managers and simulation objects.