### PR TITLE
Penalize overly complex algorithms

### DIFF
--- a/config/globals.go
+++ b/config/globals.go
@@ -50,6 +50,7 @@ func HealthChangeFromEatingAttempt() float64     { return constants.HealthChange
 func HealthChangeFromAttacking() float64         { return constants.HealthChangeFromAttacking }
 func HealthChangeInflictedByAttack() float64     { return constants.HealthChangeInflictedByAttack }
 func HealthChangeFromFeeding() float64           { return constants.HealthChangeFromFeeding }
+func HealthChangePerDecisionTreeNode() float64   { return constants.HealthChangePerDecisionTreeNode }
 func HealthPercentToChangeDecisionTree() float64 { return constants.HealthPercentToChangeDecisionTree }
 func MaxDecisionTreeSize() int                   { return constants.MaxDecisionTreeSize }
 func MaxDecisionTrees() int                      { return constants.MaxDecisionTrees }
@@ -89,14 +90,15 @@ type Globals struct {
 	MinimumMaxSize                  float64 `json:"minimum_max_size"`
 
 	// Health parameters (percent of organism size)
-	HealthChangePerCycle          float64 `json:"health_change_per_cycle"`
-	HealthChangeFromBeingIdle     float64 `json:"health_change_from_being_idle"`
-	HealthChangeFromTurning       float64 `json:"health_change_from_turning"`
-	HealthChangeFromMoving        float64 `json:"health_change_from_moving"`
-	HealthChangeFromEatingAttempt float64 `json:"health_change_from_eating_attempt"`
-	HealthChangeFromAttacking     float64 `json:"health_change_from_attacking"`
-	HealthChangeInflictedByAttack float64 `json:"health_change_inflicted_by_attack"`
-	HealthChangeFromFeeding       float64 `json:"health_change_from_feeding"`
+	HealthChangePerCycle            float64 `json:"health_change_per_cycle"`
+	HealthChangeFromBeingIdle       float64 `json:"health_change_from_being_idle"`
+	HealthChangeFromTurning         float64 `json:"health_change_from_turning"`
+	HealthChangeFromMoving          float64 `json:"health_change_from_moving"`
+	HealthChangeFromEatingAttempt   float64 `json:"health_change_from_eating_attempt"`
+	HealthChangeFromAttacking       float64 `json:"health_change_from_attacking"`
+	HealthChangeInflictedByAttack   float64 `json:"health_change_inflicted_by_attack"`
+	HealthChangeFromFeeding         float64 `json:"health_change_from_feeding"`
+	HealthChangePerDecisionTreeNode float64 `json:"health_change_per_decision_tree_node"`
 
 	// Decision tree parameters
 	HealthPercentToChangeDecisionTree float64 `json:"health_percent_to_change_decision_tree"`

--- a/manager/organism.go
+++ b/manager/organism.go
@@ -316,6 +316,11 @@ func (m *OrganismManager) OrganismCount() int {
 	return len(m.organisms)
 }
 
+// DeadCount returns the total number of organisms that have died in the simulation
+func (m *OrganismManager) DeadCount() int {
+	return m.totalOrganismsCreated - len(m.organisms)
+}
+
 func (m *OrganismManager) applyAction(o *organism.Organism) {
 	switch o.Action() {
 	case d.ActIdle:
@@ -346,6 +351,7 @@ func (m *OrganismManager) applyAction(o *organism.Organism) {
 }
 
 func (m *OrganismManager) updateHealth(o *organism.Organism) {
+	o.ApplyHealthChange(c.HealthChangePerDecisionTreeNode() * float64(o.GetCurrentDecisionTreeLength()))
 	o.ApplyHealthChange(c.HealthChangePerCycle() * o.Size)
 }
 

--- a/organism/organism.go
+++ b/organism/organism.go
@@ -230,6 +230,12 @@ func (o *Organism) GetCurrentDecisionTreeCopy(copyHistory bool) *d.Tree {
 	return o.decisionTree.CopyTree(copyHistory)
 }
 
+// GetCurrentDecisionTreeLength returns the number of nodes in the organism's currently-used
+// decision tree
+func (o *Organism) GetCurrentDecisionTreeLength() int {
+	return o.decisionTree.Size()
+}
+
 // GetAction returns the last-chosen Organism action
 func (o Organism) GetAction() d.Action { return o.action }
 

--- a/settings/default.json
+++ b/settings/default.json
@@ -27,11 +27,12 @@
   "health_change_per_cycle": -0.001,
   "health_change_from_being_idle": 0.005,
   "health_change_from_turning": -0.001,
-  "health_change_from_moving": -0.002,
+  "health_change_from_moving": -0.005,
   "health_change_from_eating_attempt": -0.0005,
   "health_change_from_attacking": -0.01,
   "health_change_inflicted_by_attack": -0.5,
   "health_change_from_feeding": -0.01,
+  "health_change_per_decision_tree_node": -0.001,
   "health_percent_to_change_decision_tree": 0.1,
   "max_decision_tree_size": 32,
   "max_decision_trees": 5

--- a/simulation/simulation.go
+++ b/simulation/simulation.go
@@ -141,6 +141,11 @@ func (s *Simulation) GetFoodCount() int {
 	return len(s.foodManager.GetFoodItems())
 }
 
+// GetDeadCount returns the total number of organisms that have died in the simulation.
+func (s *Simulation) GetDeadCount() int {
+	return s.organismManager.DeadCount()
+}
+
 // GetFoodItems returns an array of all food items in grid
 func (s *Simulation) GetFoodItems() map[string]*food.Item {
 	return s.foodManager.GetFoodItems()

--- a/ux/panel.go
+++ b/ux/panel.go
@@ -82,8 +82,8 @@ func (p *Panel) renderPlayPauseButton(panelImage *ebiten.Image) {
 }
 
 func (p *Panel) renderStats(panelImage *ebiten.Image) {
-	statsString := fmt.Sprintf("CYCLE: %9d\nORGANISMS: %5d\nFOOD:      %5d",
-		p.simulation.Cycle(), p.simulation.OrganismCount(), p.simulation.GetFoodCount())
+	statsString := fmt.Sprintf("CYCLE: %9d\nORGANISMS: %5d\nDEAD: %10d",
+		p.simulation.Cycle(), p.simulation.OrganismCount(), p.simulation.GetDeadCount())
 	text.Draw(panelImage, statsString, r.FontSourceCodePro12, statsXOffset, statsYOffset, color.White)
 }
 


### PR DESCRIPTION
Add a negative health change to be multiplied by the number of nodes in an organism's currently used decision tree, to mimic the energy expenditure on overly complex thinking. (We'll see if this helps prune unused decision tree branches....)